### PR TITLE
Add ore dictionary entries to saws

### DIFF
--- a/src/main/java/net/sharkbark/cellars/init/ModItems.java
+++ b/src/main/java/net/sharkbark/cellars/init/ModItems.java
@@ -4,7 +4,9 @@ import net.dries007.tfc.api.registries.TFCRegistries;
 import net.dries007.tfc.api.types.Metal;
 import net.dries007.tfc.types.DefaultMetals;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.sharkbark.cellars.items.ItemIceSaw;
 import net.sharkbark.cellars.items.ItemIceShard;
@@ -60,7 +62,7 @@ public class ModItems {
     public static final Item SEA_ICE_SHARD = null;
 
     public static void registerItems(IForgeRegistry<Item> registry) {
-        registry.registerAll(
+        Item[] saws = new Item[]{
             new ItemIceSaw(Metal.BRONZE, "bronze_ice_saw"),
             new ItemIceSaw(Metal.BISMUTH_BRONZE, "bismuth_bronze_ice_saw"),
             new ItemIceSaw(Metal.BLACK_BRONZE, "black_bronze_ice_saw"),
@@ -68,8 +70,10 @@ public class ModItems {
             new ItemIceSaw(Metal.STEEL, "steel_ice_saw"),
             new ItemIceSaw(TFCRegistries.METALS.getValue(DefaultMetals.BLACK_STEEL), "black_steel_ice_saw"),
             new ItemIceSaw(Metal.RED_STEEL, "red_steel_ice_saw"),
-            new ItemIceSaw(Metal.BLUE_STEEL, "blue_steel_ice_saw"),
-
+            new ItemIceSaw(Metal.BLUE_STEEL, "blue_steel_ice_saw")
+        };
+        registry.registerAll(saws);
+        registry.registerAll(
             new ItemToolHead(Metal.BRONZE, "bronze_ice_saw_head", "icesawBlade"),
             new ItemToolHead(Metal.BISMUTH_BRONZE, "bismuth_bronze_ice_saw_head", "icesawBlade"),
             new ItemToolHead(Metal.BLACK_BRONZE, "black_bronze_ice_saw_head", "icesawBlade"),
@@ -83,5 +87,12 @@ public class ModItems {
             new ItemIceShard("packed_ice_shard"),
             new ItemIceShard("sea_ice_shard")
         );
+
+        for(Item saw : saws) {
+            ItemStack stack = new ItemStack(saw, 1, OreDictionary.WILDCARD_VALUE);
+            OreDictionary.registerOre("tool", stack);
+            OreDictionary.registerOre("damageTypeSlashing", stack);
+            OreDictionary.registerOre("icesaw", stack);
+        }
     }
 }


### PR DESCRIPTION
The "tool" ore dictionary allows the saws to be placed on tool racks. The others are for consistency with other TFC tool ore dictionary entries.